### PR TITLE
ROX-8482: Bring back HTML report

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -45,7 +45,6 @@ import com.stackrox.jenkins.plugins.data.CVE;
 import com.stackrox.jenkins.plugins.data.ImageCheckResults;
 import com.stackrox.jenkins.plugins.data.PolicyViolation;
 import com.stackrox.jenkins.plugins.jenkins.RunConfig;
-import com.stackrox.jenkins.plugins.jenkins.ViewStackroxResultsAction;
 import com.stackrox.jenkins.plugins.report.ReportGenerator;
 import com.stackrox.jenkins.plugins.services.ApiClientFactory;
 import com.stackrox.jenkins.plugins.services.DetectionService;

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/ViewStackroxResultsAction.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/ViewStackroxResultsAction.java
@@ -1,4 +1,4 @@
-package com.stackrox.jenkins.plugins.jenkins;
+package com.stackrox.jenkins.plugins;
 
 import java.util.List;
 

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/CVE.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/CVE.java
@@ -1,17 +1,16 @@
 package com.stackrox.jenkins.plugins.data;
 
-import com.stackrox.model.StorageEmbeddedVulnerability;
-import com.stackrox.model.StorageVulnerabilitySeverity;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
+import com.stackrox.model.StorageEmbeddedVulnerability;
 
 @Data
 @AllArgsConstructor
 public class CVE {
     private final String packageName;
     private final String packageVersion;
-    private final StorageVulnerabilitySeverity severity;
+    private final String severity;
     private final String id;
     private final String link;
 
@@ -19,7 +18,7 @@ public class CVE {
         this(
                 packageName,
                 packageVersion,
-                vulnerability.getSeverity(),
+                SeverityUtil.prettySeverity(vulnerability.getSeverity()),
                 vulnerability.getCve(),
                 vulnerability.getLink()
         );

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/ImageCheckResults.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/ImageCheckResults.java
@@ -1,5 +1,7 @@
 package com.stackrox.jenkins.plugins.data;
 
+import com.google.gson.Gson;
+
 import java.util.List;
 
 import lombok.Data;
@@ -7,11 +9,23 @@ import lombok.Data;
 @Data
 public class ImageCheckResults {
 
+    private static final Gson GSON = new Gson();
+
     private final String imageName;
     private final List<CVE> cves;
     private final List<PolicyViolation> violatedPolicies;
 
     public boolean isStatusPass() {
         return violatedPolicies.stream().noneMatch(PolicyViolation::isBuildEnforced);
+    }
+
+    @SuppressWarnings("unused") // used by index.jelly
+    public String getCvesJson() {
+        return cves.isEmpty() ? "" : GSON.toJson(cves);
+    }
+
+    @SuppressWarnings("unused") // used by index.jelly
+    public String getViolatedPoliciesJson() {
+        return violatedPolicies.isEmpty() ? "" : GSON.toJson(violatedPolicies);
     }
 }

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/PolicyViolation.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/PolicyViolation.java
@@ -7,13 +7,12 @@ import lombok.Data;
 
 import com.stackrox.model.StorageEnforcementAction;
 import com.stackrox.model.StoragePolicy;
-import com.stackrox.model.StorageSeverity;
 
 @Data
 @AllArgsConstructor
 public class PolicyViolation {
     private final String name;
-    private final StorageSeverity severity;
+    private final String severity;
     private final String description;
     private final String remediation;
     private final String violations;
@@ -22,7 +21,7 @@ public class PolicyViolation {
     public PolicyViolation(@Nonnull StoragePolicy policy, String violations) {
         this(
                 policy.getName(),
-                policy.getSeverity(),
+                SeverityUtil.prettySeverity(policy.getSeverity()),
                 policy.getDescription(),
                 policy.getRemediation(),
                 violations,

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/SeverityUtil.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/SeverityUtil.java
@@ -1,0 +1,12 @@
+package com.stackrox.jenkins.plugins.data;
+
+import org.apache.commons.lang.StringUtils;
+
+public class SeverityUtil {
+    public static String prettySeverity(Enum<?> severity) {
+        if (severity == null) {
+            return null;
+        }
+        return StringUtils.substringBefore(severity.toString(), "_");
+    }
+}

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/report/ReportGenerator.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/report/ReportGenerator.java
@@ -14,7 +14,6 @@ import hudson.FilePath;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
-import org.apache.commons.lang.StringUtils;
 
 import com.stackrox.jenkins.plugins.data.CVE;
 import com.stackrox.jenkins.plugins.data.ImageCheckResults;
@@ -51,7 +50,7 @@ public class ReportGenerator {
                             cve.getPackageName(),
                             cve.getPackageVersion(),
                             cve.getId(),
-                            prettySeverity(cve.getSeverity()),
+                            cve.getSeverity(),
                             cve.getLink()
                     ));
                 }
@@ -64,7 +63,7 @@ public class ReportGenerator {
                 for (PolicyViolation policy : result.getViolatedPolicies()) {
                     printer.printRecord(nullIfEmpty(
                             policy.getName(),
-                            prettySeverity(policy.getSeverity()),
+                            policy.getSeverity(),
                             policy.getDescription(),
                             policy.getViolations(),
                             prettyRemediation(policy.getRemediation()),
@@ -87,13 +86,6 @@ public class ReportGenerator {
             return s;
         }
         return Strings.isNullOrEmpty(s.toString()) ? null : s;
-    }
-
-    private static String prettySeverity(Enum<?> severity) {
-        if (severity == null) {
-            return null;
-        }
-        return StringUtils.substringBefore(severity.toString(), "_");
     }
 
     private static String prettyRemediation(String remediation) {

--- a/stackrox-container-image-scanner/src/main/webapp/js/renderTables.js
+++ b/stackrox-container-image-scanner/src/main/webapp/js/renderTables.js
@@ -7,33 +7,17 @@ function renderCVETable(tableId, cves) {
         order: [[2, 'desc']],
         data: cves,
         columns : [
-                    { title: 'CVE ID', mData : function (data, type, dataToSet) {
+                    { title: 'COMPONENT', data : 'packageName' },
+                    { title: 'VERSION', data : 'packageVersion'},
+                    { title: 'CVE', mData : function (data, type, dataToSet) {
                                                     return `<a target="_blank" href="${data.link}">${data.id}</a>`;
                                                }
                     },
-                    { title: 'CVSS Score', mData : function (data, type, dataToSet) {
-                                                    if (data.cvssScore == 0) {
-                                                        return `<span>-</span>`
-                                                    }
-                                                    return `<span>${data.cvssScore}</span><span style="font-size: 10px; font-family Arial"> (${data.scoreType})</span>`;
-                                               }
-                    },
-                    { title: 'Package Name', data : 'packageName' },
-                    { title: 'Package Version', data : 'packageVersion' },
-                    { title: 'Fixable', data : 'fixable' },
-                    { title: 'Publish Date', mData : function (data, type, dataToSet) {
-                                                 if (data.publishDate == "-") {
-                                                    return `<span>-</span>`
-                                                 } else {
-                                                    var d = new Date(data.publishDate);
-                                                    return `<span>${d.getMonth()+1}/${d.getDate()}/${d.getFullYear()}</span>`
-                                                 }
-                                               }
-                   },
+                    { title: 'SEVERITY', data : 'severity' },
                 ],
         columnDefs: [
                       {
-                        targets: [0, 2, 3, 5],
+                        targets: [0, 1, 2, 3],
                         render: function (source, type, val) {
                           return `<span style="word-break: break-word;">${source}</span>`;
                         }
@@ -52,10 +36,12 @@ function renderPolicyViolationTable(tableId, violatedPolicies) {
         order: [[0, 'asc']],
         data: violatedPolicies,
         columns : [
-                    { title: 'Policy', data : 'name' },
-                    { title: 'Description', data : 'description' },
-                    { title: 'Severity', data : 'severity' },
-                    { title: 'Remediation', data : 'remediation' },
+                    { title: 'POLICY', data : 'name' },
+                    { title: 'SEVERITY', data : 'severity' },
+                    { title: 'DESCRIPTION', data : 'description' },
+                    { title: 'VIOLATION', data : 'violations' },
+                    { title: 'REMEDIATION', data : 'remediation' },
+                    { title: 'ENFORCED', data : 'buildEnforced' },
 
                 ],
         columnDefs: [
@@ -66,7 +52,7 @@ function renderPolicyViolationTable(tableId, violatedPolicies) {
                     }
                   },
                   {
-                    targets: [1, 3],
+                    targets: [2, 3, 4],
                     render: function (source, type, val) {
                       return `<span style="word-break: break-word;">${source}</span>`;
                     }


### PR DESCRIPTION
Action page was accidentally moved and two methods were removed in #50 causing report to not display. 
This PR bring this action back to it's previous place, adds removed JSON getters and adjust tables to match latest changes in CSV output.  

![image](https://user-images.githubusercontent.com/1616386/140500785-da23efb2-f541-4c80-ae55-65d85d5147df.png)
