### PR TITLE
Use hash instead of names

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/ViewStackroxResultsAction.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/ViewStackroxResultsAction.java
@@ -1,34 +1,18 @@
 package com.stackrox.jenkins.plugins;
 
-import com.google.common.net.UrlEscapers;
-
-import com.stackrox.jenkins.plugins.data.ImageCheckResults;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import hudson.model.Action;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 import lombok.Data;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Formatter;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import com.stackrox.jenkins.plugins.data.ImageCheckResults;
 
 @Data
 public class ViewStackroxResultsAction implements Action {
-    static private final MessageDigest crypt;
-
-    static {
-        try {
-            crypt = MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private final List<ImageCheckResults> results;
     private final Run<?, ?> build;
 
@@ -45,28 +29,12 @@ public class ViewStackroxResultsAction implements Action {
     @Override
     public String getUrlName() {
         String images = getNames().collect(Collectors.joining("-"));
-        return UrlEscapers.urlFragmentEscaper().escape("stackrox-image-security-results-" + getHash(images));
+        return String.format("stackrox-image-security-results-%08x", images.hashCode());
     }
 
     private Stream<String> getNames() {
         return getResults()
                 .stream()
                 .map(ImageCheckResults::getImageName);
-    }
-
-    private static String getHash(String str) {
-        crypt.reset();
-        crypt.update(str.getBytes(StandardCharsets.UTF_8));
-        return byteToHex(crypt.digest());
-    }
-
-    private static String byteToHex(final byte[] hash) {
-        Formatter formatter = new Formatter();
-        for (byte b : hash) {
-            formatter.format("%02x", b);
-        }
-        String result = formatter.toString();
-        formatter.close();
-        return result;
     }
 }

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/ViewStackroxResultsActionTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/ViewStackroxResultsActionTest.java
@@ -42,13 +42,13 @@ class ViewStackroxResultsActionTest {
 
     private static Stream<TestCase> getNameShouldReturnJoinedAndEscapedNames() {
         return Stream.of(
-                new TestCase(Stream.of(), "da39a3ee5e6b4b0d3255bfef95601890afd80709", ""),
-                new TestCase(Stream.of(""), "da39a3ee5e6b4b0d3255bfef95601890afd80709", ""),
-                new TestCase(Stream.of(" "), "b858cb282617fb0956d960215c8e84d1ccf909c6", " "),
-                new TestCase(Stream.of("nginx:latest"), "e021805d28895ba97695d3db7563b11c2766f3b3", "nginx:latest"),
-                new TestCase(Stream.of("nginx:latest", "ubuntu:bionic"), "dfdfc828833c2b2e77f4bf9068cfa72d36ee65a4", "nginx:latest, ubuntu:bionic"),
-                new TestCase(Stream.of("ubuntu:bionic", "nginx:latest"), "e4358c9bd0ac3e446d4df99e4d49333cd595c280", "ubuntu:bionic, nginx:latest"),
-                new TestCase(Stream.of("<html>", "<alert>", ""), "f7b8ceff87bcbfe1ad536aae577d3266a50c47d9", "<html>, <alert>, ")
+                new TestCase(Stream.of(), "00000000", ""),
+                new TestCase(Stream.of(""), "00000000", ""),
+                new TestCase(Stream.of(" "), "00000020", " "),
+                new TestCase(Stream.of("nginx:latest"), "896f1767", "nginx:latest"),
+                new TestCase(Stream.of("nginx:latest", "ubuntu:bionic"), "b742880d", "nginx:latest, ubuntu:bionic"),
+                new TestCase(Stream.of("ubuntu:bionic", "nginx:latest"), "9da07f01", "ubuntu:bionic, nginx:latest"),
+                new TestCase(Stream.of("<html>", "<alert>", ""), "57e8ac25", "<html>, <alert>, ")
         );
     }
 }


### PR DESCRIPTION
To prevent long URL let's use [Java hashCode](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#hashCode--) of images. All links will have the same length.