### PR TITLE
Reduce dependabot frequency from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: 'maven'
     directory: 'stackrox-container-image-scanner/'
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "stackrox/backend-dep-updaters"
 
   - package-ecosystem: 'gradle'
     directory: 'functionaltest-jenkins-plugin/'
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "stackrox/backend-dep-updaters"
 


### PR DESCRIPTION
We do not release that often so daily updates makes no sense. Monthly will be enough 