### PR TITLE
ROX-9470: Revert old report CSV format

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/CVE.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/data/CVE.java
@@ -1,26 +1,40 @@
 package com.stackrox.jenkins.plugins.data;
 
+import com.google.common.base.Strings;
+
+import com.stackrox.model.StorageEmbeddedVulnerability;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import com.stackrox.model.StorageEmbeddedVulnerability;
+import javax.annotation.Nonnull;
+
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 @Data
 @AllArgsConstructor
 public class CVE {
+    private final String id;
+    private final Float cvssScore;
+    private final String scoreType;
+    private final String publishDate;
     private final String packageName;
     private final String packageVersion;
-    private final String severity;
-    private final String id;
+    private final boolean fixable;
     private final String link;
+    private final String severity;
 
-    public CVE(String packageName, String packageVersion, StorageEmbeddedVulnerability vulnerability) {
+    public CVE(String packageName, String packageVersion, @Nonnull StorageEmbeddedVulnerability vulnerability) {
         this(
+                vulnerability.getCve(),
+                vulnerability.getCvss(),
+                vulnerability.getScoreVersion() != null ? vulnerability.getScoreVersion().toString() : null,
+                vulnerability.getPublishedOn() != null ? vulnerability.getPublishedOn().format(ISO_DATE_TIME) : null,
                 packageName,
                 packageVersion,
-                SeverityUtil.prettySeverity(vulnerability.getSeverity()),
-                vulnerability.getCve(),
-                vulnerability.getLink()
+                !Strings.isNullOrEmpty(vulnerability.getFixedBy()),
+                vulnerability.getLink(),
+                SeverityUtil.prettySeverity(vulnerability.getSeverity())
         );
     }
 }

--- a/stackrox-container-image-scanner/src/test/resources/report/jenkins.lts/cves.csv
+++ b/stackrox-container-image-scanner/src/test/resources/report/jenkins.lts/cves.csv
@@ -1,4 +1,4 @@
-COMPONENT,VERSION,CVE,SEVERITY,LINK
-util-linux,2.25.2-6,CVE-2015-5224,IMPORTANT,https://security-tracker.debian.org/tracker/CVE-2015-5224
-gcc-4.8,4.8.4-1,CVE-2017-11671,MODERATE,https://security-tracker.debian.org/tracker/CVE-2017-11671
-bzip2,1.0.6-7,CVE-2016-3189,LOW,https://security-tracker.debian.org/tracker/CVE-2016-3189
+"CVE ID","CVSS Score","Score Type","Package Name","Package Version","Fixable","Publish Date","Link"
+"CVE-2015-5224",9.8,"V3","util-linux","2.25.2-6","false","2017-08-23T15:29:00Z","https://security-tracker.debian.org/tracker/CVE-2015-5224"
+"CVE-2017-11671",4.0,"V3","gcc-4.8","4.8.4-1","false","2017-07-26T21:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-11671"
+"CVE-2016-3189",6.5,"V3","bzip2","1.0.6-7","true","2016-06-30T17:59:00Z","https://security-tracker.debian.org/tracker/CVE-2016-3189"

--- a/stackrox-container-image-scanner/src/test/resources/report/jenkins.lts/policyViolations.csv
+++ b/stackrox-container-image-scanner/src/test/resources/report/jenkins.lts/policyViolations.csv
@@ -1,2 +1,2 @@
-POLICY,SEVERITY,DESCRIPTION,VIOLATION,REMEDIATION,ENFORCED
-Fixable Severity at least Important,HIGH,Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important,-,Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.,X
+"Policy Name","Policy Description","Severity","Remediation"
+"Fixable Severity at least Important","Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important","HIGH","Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities."

--- a/stackrox-container-image-scanner/src/test/resources/report/nginx.latest/cves.csv
+++ b/stackrox-container-image-scanner/src/test/resources/report/nginx.latest/cves.csv
@@ -1,3 +1,3 @@
-COMPONENT,VERSION,CVE,SEVERITY,LINK
-openssl,1.1.1d-0+deb10u7,CVE-2007-6755,LOW,https://security-tracker.debian.org/tracker/CVE-2007-6755
--,-,-,UNKNOWN,-
+"CVE ID","CVSS Score","Score Type","Package Name","Package Version","Fixable","Publish Date","Link"
+"CVE-2007-6755",5.8,"V2","openssl","1.1.1d-0+deb10u7","false","2013-10-11T22:55:00Z","https://security-tracker.debian.org/tracker/CVE-2007-6755"
+"CVE-MISSING-DATA",0.0,"-","-","-","false","-","-"

--- a/stackrox-container-image-scanner/src/test/resources/report/nginx.latest/policyViolations.csv
+++ b/stackrox-container-image-scanner/src/test/resources/report/nginx.latest/policyViolations.csv
@@ -1,3 +1,3 @@
-POLICY,SEVERITY,DESCRIPTION,VIOLATION,REMEDIATION,ENFORCED
-Latest Tag,MEDIUM,-,Image has tag 'latest',No remediation actions documented.,-
-Fixable Severity at least Important,HIGH,Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important,-,Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.,-
+"Policy Name","Policy Description","Severity","Remediation"
+"Latest Tag","","MEDIUM","No remediation actions documented."
+"Fixable Severity at least Important","Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important","HIGH","Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities."


### PR DESCRIPTION
This PR reeverts #82 to bring back old CSV format. 
It does NOT change reports UI so they looks like before.
This change was requested by a customer because in #82 we broke backward compatibility and they miss some data that were available before.


Example output for `nginx:latest` below

<details>


![localhost_8080_job_test_1_stackrox-image-security-results-896f1767_ (1)](https://user-images.githubusercontent.com/1616386/157726955-f1476154-0f83-41b0-b483-76bdc5688680.png)

![localhost_8080_job_test_1_stackrox-image-security-results-896f1767_](https://user-images.githubusercontent.com/1616386/157726969-2385bae8-6dc7-4366-aef1-aeea0aa8ad25.png)

```csv
"Policy Name","Policy Description","Severity","Remediation"
"Latest tag","Alert on deployments with images using tag 'latest'","LOW","Consider moving to semantic versioning based on code releases (semver.org) or using the first 12 characters of the source control SHA. This will allow you to tie the Docker image to the code."
"Ubuntu Package Manager in Image","Alert on deployments with components of the Debian/Ubuntu package management system in the image.","LOW","Run `dpkg -r --force-all apt apt-get && dpkg -r --force-all debconf dpkg` in the image build for production containers."
"Docker CIS 4.1: Ensure That a User for the Container Has Been Created","Containers should run as a non-root user","LOW","Ensure that the Dockerfile for each container switches from the root user"
```

```csv
"CVE ID","CVSS Score","Score Type","Package Name","Package Version","Fixable","Publish Date","Link"
"CVE-2016-2781",6.5,"V3","coreutils","8.32-4","false","2017-02-07T15:59:00Z","https://security-tracker.debian.org/tracker/CVE-2016-2781"
"CVE-2017-18018",4.7,"V3","coreutils","8.32-4","false","2018-01-04T04:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-18018"
"CVE-2022-0561",5.5,"V3","tiff","4.2.0-1","false","2022-02-11T18:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-0561"
"CVE-2017-17973",8.8,"V3","tiff","4.2.0-1","false","2017-12-29T21:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-17973"
"CVE-2017-9117",9.8,"V3","tiff","4.2.0-1","false","2017-05-21T19:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-9117"
"CVE-2014-8130",6.5,"V3","tiff","4.2.0-1","false","2018-03-12T02:29:00Z","https://security-tracker.debian.org/tracker/CVE-2014-8130"
"CVE-2018-10126",6.5,"V3","tiff","4.2.0-1","false","2018-04-21T21:29:00Z","https://security-tracker.debian.org/tracker/CVE-2018-10126"
"CVE-2017-5563",8.8,"V3","tiff","4.2.0-1","false","2017-01-23T07:59:00Z","https://security-tracker.debian.org/tracker/CVE-2017-5563"
"CVE-2017-16232",7.5,"V3","tiff","4.2.0-1","false","2019-03-21T15:59:00Z","https://security-tracker.debian.org/tracker/CVE-2017-16232"
"CVE-2022-0562",5.5,"V3","tiff","4.2.0-1","false","2022-02-11T18:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-0562"
"CVE-2022-22844",5.5,"V3","tiff","4.2.0-1","false","2022-01-10T14:12:00Z","https://security-tracker.debian.org/tracker/CVE-2022-22844"
"CVE-2017-11164",7.5,"V3","pcre3","2:8.39-13","false","2017-07-11T03:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-11164"
"CVE-2017-7246",7.8,"V3","pcre3","2:8.39-13","false","2017-03-23T21:59:00Z","https://security-tracker.debian.org/tracker/CVE-2017-7246"
"CVE-2017-16231",5.5,"V3","pcre3","2:8.39-13","false","2019-03-21T15:59:00Z","https://security-tracker.debian.org/tracker/CVE-2017-16231"
"CVE-2019-20838",7.5,"V3","pcre3","2:8.39-13","false","2020-06-15T17:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-20838"
"CVE-2017-7245",7.8,"V3","pcre3","2:8.39-13","false","2017-03-23T21:59:00Z","https://security-tracker.debian.org/tracker/CVE-2017-7245"
"CVE-2021-36086",3.3,"V3","libsepol","3.1-1","false","2021-07-01T03:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-36086"
"CVE-2021-36087",3.3,"V3","libsepol","3.1-1","false","2021-07-01T03:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-36087"
"CVE-2021-36085",3.3,"V3","libsepol","3.1-1","false","2021-07-01T03:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-36085"
"CVE-2021-36084",3.3,"V3","libsepol","3.1-1","false","2021-07-01T03:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-36084"
"CVE-2017-9937",6.5,"V3","jbigkit","2.1-3.1","false","2017-06-26T12:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-9937"
"CVE-2011-3374",3.7,"V3","apt","2.2.4","false","2019-11-26T00:15:00Z","https://security-tracker.debian.org/tracker/CVE-2011-3374"
"CVE-2011-4116",7.5,"V3","perl","5.32.1-4+deb11u2","false","2020-01-31T18:15:00Z","https://security-tracker.debian.org/tracker/CVE-2011-4116"
"CVE-2020-16156",7.8,"V3","perl","5.32.1-4+deb11u2","false","2021-12-13T18:15:00Z","https://security-tracker.debian.org/tracker/CVE-2020-16156"
"CVE-2009-4487",6.8,"V2","nginx","1.21.6-1~bullseye","false","2010-01-13T20:30:00Z","https://security-tracker.debian.org/tracker/CVE-2009-4487"
"CVE-2020-36309",5.3,"V3","nginx","1.21.6-1~bullseye","false","2021-04-06T19:15:00Z","https://security-tracker.debian.org/tracker/CVE-2020-36309"
"CVE-2013-0337",7.5,"V2","nginx","1.21.6-1~bullseye","false","2013-10-27T00:55:00Z","https://security-tracker.debian.org/tracker/CVE-2013-0337"
"CVE-2022-23218",9.8,"V3","glibc","2.31-13+deb11u2","false","2022-01-14T07:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-23218"
"CVE-2010-4756",4.0,"V2","glibc","2.31-13+deb11u2","false","2011-03-02T20:00:00Z","https://security-tracker.debian.org/tracker/CVE-2010-4756"
"CVE-2019-1010024",5.3,"V3","glibc","2.31-13+deb11u2","false","2019-07-15T04:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-1010024"
"CVE-2021-43396",7.5,"V3","glibc","2.31-13+deb11u2","false","2021-11-04T20:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-43396"
"CVE-2019-1010025",5.3,"V3","glibc","2.31-13+deb11u2","false","2019-07-15T04:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-1010025"
"CVE-2022-23219",9.8,"V3","glibc","2.31-13+deb11u2","false","2022-01-14T07:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-23219"
"CVE-2018-20796",7.5,"V3","glibc","2.31-13+deb11u2","false","2019-02-26T02:29:00Z","https://security-tracker.debian.org/tracker/CVE-2018-20796"
"CVE-2019-1010022",9.8,"V3","glibc","2.31-13+deb11u2","false","2019-07-15T04:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-1010022"
"CVE-2019-9192",7.5,"V3","glibc","2.31-13+deb11u2","false","2019-02-26T18:29:00Z","https://security-tracker.debian.org/tracker/CVE-2019-9192"
"CVE-2019-1010023",8.8,"V3","glibc","2.31-13+deb11u2","false","2019-07-15T04:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-1010023"
"CVE-2021-33574",9.8,"V3","glibc","2.31-13+deb11u2","false","2021-05-25T22:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-33574"
"CVE-2019-6129",6.5,"V3","libpng1.6","1.6.37-3","false","2019-01-11T05:29:00Z","https://security-tracker.debian.org/tracker/CVE-2019-6129"
"CVE-2021-38115",6.5,"V3","libgd2","2.3.0-2","false","2021-08-04T21:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-38115"
"CVE-2021-40812",6.5,"V3","libgd2","2.3.0-2","false","2021-09-08T21:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-40812"
"CVE-2021-40145",7.5,"V3","libgd2","2.3.0-2","false","2021-08-26T01:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-40145"
"CVE-2015-3276",5.0,"V2","openldap","2.4.57+dfsg-3","false","2015-12-07T20:59:00Z","https://security-tracker.debian.org/tracker/CVE-2015-3276"
"CVE-2020-15719",4.2,"V3","openldap","2.4.57+dfsg-3","false","2020-07-14T14:15:00Z","https://security-tracker.debian.org/tracker/CVE-2020-15719"
"CVE-2017-14159",4.7,"V3","openldap","2.4.57+dfsg-3","false","2017-09-05T18:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-14159"
"CVE-2017-17740",7.5,"V3","openldap","2.4.57+dfsg-3","false","2017-12-18T06:29:00Z","https://security-tracker.debian.org/tracker/CVE-2017-17740"
"CVE-2016-9085",3.3,"V3","libwebp","0.6.1-2.1","false","2017-02-03T15:59:00Z","https://security-tracker.debian.org/tracker/CVE-2016-9085"
"CVE-2015-9019",5.3,"V3","libxslt","1.1.34-4","false","2017-04-05T21:59:00Z","https://security-tracker.debian.org/tracker/CVE-2015-9019"
"CVE-2005-2541",10.0,"V2","tar","1.34+dfsg-1","false","2005-08-10T04:00:00Z","https://security-tracker.debian.org/tracker/CVE-2005-2541"
"CVE-2011-3389",4.3,"V2","gnutls28","3.7.1-5","false","2011-09-06T19:55:00Z","https://security-tracker.debian.org/tracker/CVE-2011-3389"
"CVE-2021-22946",7.5,"V3","curl","7.74.0-1.3+deb11u1","false","2021-09-29T20:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22946"
"CVE-2021-22924",3.7,"V3","curl","7.74.0-1.3+deb11u1","false","2021-08-05T21:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22924"
"CVE-2021-22922",6.5,"V3","curl","7.74.0-1.3+deb11u1","false","2021-08-05T21:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22922"
"CVE-2021-22898",3.1,"V3","curl","7.74.0-1.3+deb11u1","false","2021-06-11T16:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22898"
"CVE-2021-22947",5.9,"V3","curl","7.74.0-1.3+deb11u1","false","2021-09-29T20:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22947"
"CVE-2021-22923",5.3,"V3","curl","7.74.0-1.3+deb11u1","false","2021-08-05T21:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22923"
"CVE-2021-22945",9.1,"V3","curl","7.74.0-1.3+deb11u1","false","2021-09-23T13:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-22945"
"CVE-2013-4392",3.3,"V2","systemd","247.3-6","false","2013-10-28T22:55:00Z","https://security-tracker.debian.org/tracker/CVE-2013-4392"
"CVE-2020-13529",6.1,"V3","systemd","247.3-6","false","2021-05-10T16:15:00Z","https://security-tracker.debian.org/tracker/CVE-2020-13529"
"CVE-2021-39537",8.8,"V3","ncurses","6.2+20201114-2","false","2021-09-20T16:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-39537"
"CVE-2018-5709",7.5,"V3","krb5","1.18.3-6+deb11u1","false","2018-01-16T09:29:00Z","https://security-tracker.debian.org/tracker/CVE-2018-5709"
"CVE-2004-0971",2.1,"V2","krb5","1.18.3-6+deb11u1","false","2005-02-09T05:00:00Z","https://security-tracker.debian.org/tracker/CVE-2004-0971"
"CVE-2022-23308",7.5,"V3","libxml2","2.9.10+dfsg-6.7","false","2022-02-26T05:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-23308"
"CVE-2013-4235",4.7,"V3","shadow","1:4.8.1-1","false","2019-12-03T15:15:00Z","https://security-tracker.debian.org/tracker/CVE-2013-4235"
"CVE-2007-5686",4.9,"V2","shadow","1:4.8.1-1","false","2007-10-28T17:08:00Z","https://security-tracker.debian.org/tracker/CVE-2007-5686"
"CVE-2019-19882",7.8,"V3","shadow","1:4.8.1-1","false","2019-12-18T16:15:00Z","https://security-tracker.debian.org/tracker/CVE-2019-19882"
"CVE-2010-0928",4.0,"V2","openssl","1.1.1k-1+deb11u1","false","2010-03-05T19:30:00Z","https://security-tracker.debian.org/tracker/CVE-2010-0928"
"CVE-2007-6755",5.8,"V2","openssl","1.1.1k-1+deb11u1","false","2013-10-11T22:55:00Z","https://security-tracker.debian.org/tracker/CVE-2007-6755"
"CVE-2021-4160",5.9,"V3","openssl","1.1.1k-1+deb11u1","false","2022-01-28T22:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-4160"
"CVE-2013-0340",6.8,"V2","expat","2.2.10-2+deb11u2","false","2014-01-21T18:55:00Z","https://security-tracker.debian.org/tracker/CVE-2013-0340"
"CVE-2018-6829",7.5,"V3","libgcrypt20","1.8.7-6","false","2018-02-07T23:29:00Z","https://security-tracker.debian.org/tracker/CVE-2018-6829"
"CVE-2021-33560",7.5,"V3","libgcrypt20","1.8.7-6","false","2021-06-08T11:15:00Z","https://security-tracker.debian.org/tracker/CVE-2021-33560"
"CVE-2022-0563",5.5,"V3","util-linux","2.36.1-8+deb11u1","false","2022-02-21T19:15:00Z","https://security-tracker.debian.org/tracker/CVE-2022-0563"
```

</details>