### PR TITLE
Fix tests by using pinned jenkins image

### DIFF
--- a/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
+++ b/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
@@ -61,9 +61,9 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         "data inputs are: "
-        imageName             | policyName          | tag
-        "jenkins/jenkins:lts" | "Fixable CVSS >= 7" | "lts"
-        "nginx:latest"        | "Latest tag"        | "latest"
+        imageName              | policyName          | tag
+        "jenkins/jenkins:2.77" | "Fixable CVSS >= 7" | "2.77"
+        "nginx:latest"         | "Latest tag"        | "latest"
     }
 
     @Unroll


### PR DESCRIPTION
Jenkins LTS image was updated recently and it no longer violates policy.
This PR switch from LTS to 2.77 to ensure policy is violated.
