### PR TITLE
Use git over https in pom.xml

### DIFF
--- a/stackrox-container-image-scanner/pom.xml
+++ b/stackrox-container-image-scanner/pom.xml
@@ -34,8 +34,8 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/stackrox/jenkins-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:stackrox/jenkins-plugin.git</developerConnection>
+        <connection>scm:git:https://github.com/stackrox/jenkins-plugin.git</connection>
+        <developerConnection>scm:git:https://github.com/stackrox/jenkins-plugin.git</developerConnection>
         <url>https://github.com/stackrox/jenkins-plugin</url>
       <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
To release from github action we need to push commits and tags. The Github token is only supported in HTTPS connection (not SSH). This RP changes git connection strings from SSH to HTTPS to allow releases from github action.