### PR TITLE
Update schema to include names in image added in 3.74

### DIFF
--- a/stackrox-container-image-scanner/api.yaml
+++ b/stackrox-container-image-scanner/api.yaml
@@ -11665,6 +11665,10 @@ components:
           type: string
         name:
           $ref: '#/components/schemas/storageImageName'
+        names:
+          type: array
+          items:
+            $ref: '#/components/schemas/storageImageName'
         metadata:
           $ref: '#/components/schemas/storageImageMetadata'
         scan:

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ImageServiceTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ImageServiceTest.java
@@ -24,6 +24,8 @@ import com.stackrox.model.StorageEmbeddedVulnerability;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ImageServiceTest extends AbstractServiceTest {
 
@@ -60,10 +62,11 @@ class ImageServiceTest extends AbstractServiceTest {
         assertEquals("Did not get scan results from StackRox", exception.getMessage());
     }
 
-    @Test
-    public void shouldNotFailOnMissingData() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {"minimal.json", "minimal-with-names.json"})
+    public void shouldNotFailOnMissingData(String file) throws IOException {
         MOCK_SERVER.stubFor(postImagesScan().willReturn(
-                ok().withBodyFile("v1/images/scan/minimal.json")));
+                ok().withBodyFile("v1/images/scan/" + file)));
         List<CVE> actual = imageService.getImageScanResults("nginx:latest");
         ImmutableList<CVE> expected = ImmutableList.of(
                 new CVE(null, null, new StorageEmbeddedVulnerability()

--- a/stackrox-container-image-scanner/src/test/resources/__files/v1/images/scan/minimal-with-names.json
+++ b/stackrox-container-image-scanner/src/test/resources/__files/v1/images/scan/minimal-with-names.json
@@ -1,0 +1,14 @@
+{
+  "names": [{}],
+  "scan": {
+    "components": [
+      {
+        "vulns": [
+          {
+            "cve": "CVE-MISSING-DATA"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR add `names` field introduced in `3.74`. This additional field causes errors because of issues in openapi-generator that does not handle unknown fields correctly when they are arrays.

Refs: 
- https://github.com/OpenAPITools/openapi-generator/issues/12550#issuecomment-1240358272