### PR TITLE
Migrate from dockerhub to quay

### DIFF
--- a/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
+++ b/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
@@ -20,9 +20,14 @@ import spock.lang.Unroll
 class ImageScanningTest extends BaseSpecification {
 
     protected static final String CENTRAL_URI = Config.centralUri
+    protected static final String QUAY_REPO = "quay.io/openshifttest/"
 
     @Unroll
     def "image scanning test with toggle enforcement(#imageName, #policyName,  #enforcements, #endStatus)"() {
+        given:
+        updatePolicy("Fixable CVSS >= 7", "latest", [])
+        updatePolicy("Fixable Severity at least Important", "latest", [])
+
         when:
         StoragePolicy enforcementPolicy = updatePolicy(policyName, "latest", enforcements)
 
@@ -39,9 +44,9 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         "data inputs are: "
-        imageName      | policyName   | enforcements             | endStatus
-        "nginx:latest" | "Latest tag" | []                       | SUCCESS
-        "nginx:latest" | "Latest tag" | [FAIL_BUILD_ENFORCEMENT] | FAILURE
+        imageName             | policyName   | enforcements             | endStatus
+        "nginx-alpine:latest" | "Latest tag" | []                       | SUCCESS
+        "nginx-alpine:latest" | "Latest tag" | [FAIL_BUILD_ENFORCEMENT] | FAILURE
     }
 
     @Unroll
@@ -63,9 +68,9 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         "data inputs are: "
-        imageName              | policyName          | tag
-        "jenkins/jenkins:2.77" | "Fixable CVSS >= 7" | "2.77"
-        "nginx:latest"         | "Latest tag"        | "latest"
+        imageName             | policyName          | tag
+        "nginx-alpine:1.2.1"  | "Fixable CVSS >= 7" | "1.2.1"
+        "nginx-alpine:latest" | "Latest tag"        | "latest"
     }
 
     @Unroll
@@ -79,14 +84,14 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         "data inputs are: "
-        imageName         | failOnCriticalPluginError | endStatus
-        "postgres:latest" | true                      | SUCCESS
-        "mis-spelled:lts" | true                      | FAILURE
-        "mis-spelled:lts" | false                     | SUCCESS
+        imageName             | failOnCriticalPluginError | endStatus
+        "nginx-alpine:latest" | true                      | SUCCESS
+        "mis-spelled:lts"     | true                      | FAILURE
+        "mis-spelled:lts"     | false                     | SUCCESS
     }
 
     String getJobConfig(String imageName, Boolean policyEvalCheck, Boolean failOnCriticalPluginError) {
-        return createJobConfig(imageName, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError)
+        return createJobConfig(QUAY_REPO + imageName, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError)
     }
 
     StoragePolicy updatePolicy(String policyName, String tag, List<StorageEnforcementAction> enforcements) {

--- a/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTestNoFileTest.groovy
+++ b/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTestNoFileTest.groovy
@@ -3,6 +3,7 @@ import static JenkinsClient.createJobConfigNoFile
 class ImageScanningTestNoFileTest extends ImageScanningTest {
     @Override
     String getJobConfig(String imageName, Boolean policyEvalCheck, Boolean failOnCriticalPluginError) {
-        return createJobConfigNoFile(imageName, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError)
+        String image = QUAY_REPO + imageName
+        return createJobConfigNoFile(image, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError)
     }
 }


### PR DESCRIPTION
> The best defense against the Docker Hub rate limiting is to move any base images needed to quay.io directly. Quay.io does not restrict the number of public repositories for any user (either free or paid). In addition, quay.io does not restrict anonymous pulls against its repositories (either public or private) and only rate limits in the most severe circumstances to maintain service levels (e.g. tens of requests per second from the same IP address).

https://access.redhat.com/articles/5531191