### PR TITLE
Skip code scan on pulls and e2e on external contributions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,7 @@ jobs:
       uses: github/codeql-action/analyze@v2
 
   e2e:
+    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
   schedule:
   - cron:  '0 5 * * *'
 
@@ -29,6 +34,7 @@ jobs:
         cache: 'maven'
 
     - name: Initialize CodeQL
+      if: github.event_name == 'push'
       uses: github/codeql-action/init@v2
       with:
         languages: java, javascript
@@ -45,6 +51,7 @@ jobs:
         path: stackrox-container-image-scanner/target/stackrox-container-image-scanner.jar
 
     - name: Perform CodeQL Analysis
+      if: github.event_name == 'push'
       uses: github/codeql-action/analyze@v2
 
   e2e:


### PR DESCRIPTION
> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

- https://github.com/stackrox/stackrox/pull/5350