### PR TITLE
ROX-16728: On validation show concrete error

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -257,7 +257,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
                     return FormValidation.ok("Success");
                 }
                 return FormValidation.error("Invalid credentials, user not authenticated");
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 Throwable e = Throwables.getRootCause(ex);
                 if (e instanceof ServiceException) {
                     return FormValidation.error(e, "Invalid response from central");

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -264,7 +264,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
                 } else if (e instanceof UnknownHostException) {
                     return FormValidation.error(e, "Unknown host " + portalAddress);
                 } else if (e instanceof SSLException) {
-                    return FormValidation.error(e, "Could not validate SSL");
+                    return FormValidation.error(e, "Could not validate TLS");
                 } else if (e instanceof SocketException) {
                     return FormValidation.error(e, "Connection error");
                 }

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -3,6 +3,7 @@ package com.stackrox.jenkins.plugins;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -47,7 +48,10 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.POST;
 
 import javax.annotation.Nonnull;
+import javax.net.ssl.SSLException;
 import java.io.IOException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.List;
 
 import static com.stackrox.jenkins.plugins.services.ApiClientFactory.StackRoxTlsValidationMode.INSECURE_ACCEPT_ANY;
@@ -252,9 +256,19 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
                 if (checkRoxAuthStatus(portalAddress, apiToken, tlsVerify, caCertPEM)) {
                     return FormValidation.ok("Success");
                 }
-                return FormValidation.error(Messages.StackroxBuilder_TestConnectionError());
-            } catch (Exception e) {
-                return FormValidation.error(e, Messages.StackroxBuilder_TestConnectionError());
+                return FormValidation.error("Invalid credentials, user not authenticated");
+            } catch (IOException ex) {
+                Throwable e = Throwables.getRootCause(ex);
+                if (e instanceof ServiceException) {
+                    return FormValidation.error(e, "Invalid response from central");
+                } else if (e instanceof UnknownHostException) {
+                    return FormValidation.error(e, "Unknown host " + portalAddress);
+                } else if (e instanceof SSLException) {
+                    return FormValidation.error(e, "Could not validate SSL");
+                } else if (e instanceof SocketException) {
+                    return FormValidation.error(e, "Connection error");
+                }
+                return FormValidation.error(ex, Messages.StackroxBuilder_TestConnectionError());
             }
         }
 
@@ -264,7 +278,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
                 V1AuthStatus status = new AuthServiceApi(apiClient).authServiceGetAuthStatus();
                 return !Strings.isNullOrEmpty(status.getUserId());
             } catch (ApiException e) {
-                throw ServiceException.fromApiException("Could not get auth status.", e);
+                throw ServiceException.fromApiException("Could not get auth status", e);
             }
         }
 

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -262,13 +262,13 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
                 if (e instanceof ServiceException) {
                     return FormValidation.error(e, "Invalid response from StackRox portal");
                 } else if (e instanceof UnknownHostException) {
-                    return FormValidation.error(e, "Unknown host " + portalAddress);
+                    return FormValidation.error(e, "Unknown host: " + portalAddress);
                 } else if (e instanceof SSLException) {
                     return FormValidation.error(e, "Could not validate TLS");
                 } else if (e instanceof SocketException) {
                     return FormValidation.error(e, "Connection error");
                 }
-                return FormValidation.error(ex, Messages.StackroxBuilder_TestConnectionError());
+                return FormValidation.error(ex, "Failed to connect to StackRox portal, please provide a valid portal address and API token");
             }
         }
 

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -260,7 +260,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
             } catch (Exception ex) {
                 Throwable e = Throwables.getRootCause(ex);
                 if (e instanceof ServiceException) {
-                    return FormValidation.error(e, "Invalid response from central");
+                    return FormValidation.error(e, "Invalid response from StackRox portal");
                 } else if (e instanceof UnknownHostException) {
                     return FormValidation.error(e, "Unknown host " + portalAddress);
                 } else if (e instanceof SSLException) {

--- a/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/Messages.properties
+++ b/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/Messages.properties
@@ -1,5 +1,3 @@
 StackroxBuilder.DescriptorImpl.DisplayName=StackRox Container Image Scanner
 StackroxBuilder.InvalidPortalAddressError=Please enter a valid StackRox portal address
 StackroxBuilder.EmptyAPITokenError=Please enter a valid StackRox API token
-StackroxBuilder.TestConnectionError=Failed to connect to StackRox portal, please provide a valid portal address and API token
-


### PR DESCRIPTION
When user wan to validate configuration currently they will get generic message and stack trace in details. 
This PR 
- alters the message based on root cause.
- fixes page crash (unhandled exception) when user input invalid URL 

- wrong answer from central (maybe it's not central at all or token is wrong)
![404](https://github.com/stackrox/jenkins-plugin/assets/1616386/7268378b-eeb2-4fe8-ba5c-78bd20b27fe0)
- port is not listening
![Screenshot 2023-06-21 at 16-54-07 Konfiguracja sdffsd Jenkins](https://github.com/stackrox/jenkins-plugin/assets/1616386/b793f426-1aff-452a-a939-c9127565e39e)
- wrong certificate
![tls](https://github.com/stackrox/jenkins-plugin/assets/1616386/a9bf9f58-f951-46d5-b97a-64006660ef5e)
- unknown host
![unknownhost](https://github.com/stackrox/jenkins-plugin/assets/1616386/8648a9c9-a018-4ce3-b869-e038061c8185)


