### PR TITLE
ROX-19985: Test in RH GCP

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,7 +99,7 @@ jobs:
     - name: Create GKE cluster
       id: create-cluster
       env:
-        GCLOUD_SERVICE_ACCOUNT_CI_ROX: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_OPENSHIFT_CI_ROX }}
+        GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       run: |
         cd stackrox
         source "scripts/ci/gke.sh"


### PR DESCRIPTION
# Description

Per https://issues.redhat.com/browse/ROX-19985, and use the same key name as stackrox/stackrox. Cluster is created in the new project: https://github.com/stackrox/jenkins-plugin/actions/runs/6502381837/job/17661371924?pr=279#step:12:45 :heavy_check_mark: 