### PR TITLE
chore(e2e): refactor e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,8 +118,6 @@ jobs:
           echo "ROX_ENDPOINT=$ROX_ENDPOINT" >> $GITHUB_ENV   
 
       - name: Run tests
-        env:
-          JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
         run: |
           echo $ROX_ENDPOINT
           make -C functionaltest-jenkins-plugin test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,13 +113,12 @@ jobs:
           ROX_PASSWORD=$(cat ${ARTIFACTS_DIR}/admin-password)
           ROX_ENDPOINT=$(cat ${ARTIFACTS_DIR}/url)
           echo "::add-mask::$ROX_PASSWORD"
-          #echo "::add-mask::$ROX_ENDPOINT"
+          echo "::add-mask::$ROX_ENDPOINT"
           echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
           echo "ROX_ENDPOINT=$ROX_ENDPOINT" >> $GITHUB_ENV   
 
       - name: Run tests
         env:
-          ROX_ENDPOINT: https://${{ env.ROX_ENDPOINT }}
           JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
         run: |
           echo $ROX_ENDPOINT

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,130 +8,123 @@ on:
       - "*"
   pull_request:
   schedule:
-  - cron:  '0 5 * * *'
+    - cron: '0 5 * * *'
 
 jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-        cache: 'gradle'
-    - name: Check style
-      run: make -C functionaltest-jenkins-plugin style
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+      - name: Check style
+        run: make -C functionaltest-jenkins-plugin style
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-        cache: 'maven'
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
 
-    - name: Initialize CodeQL
-      if: github.event_name == 'push'
-      uses: github/codeql-action/init@v3
-      with:
-        languages: java, javascript
+      - name: Initialize CodeQL
+        if: github.event_name == 'push'
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java, javascript
 
-    - name: Build with Maven
-      run: cd stackrox-container-image-scanner && ./mvnw -B verify package hpi:hpi cyclonedx:makeAggregateBom
-    - uses: actions/upload-artifact@v4
-      with:
-        name: stackrox-container-image-scanner.hpi
-        path: stackrox-container-image-scanner/target/stackrox-container-image-scanner.hpi
-    - uses: actions/upload-artifact@v4
-      with:
-        name: stackrox-container-image-scanner.jar
-        path: stackrox-container-image-scanner/target/stackrox-container-image-scanner.jar
+      - name: Build with Maven
+        run: cd stackrox-container-image-scanner && ./mvnw -B verify package hpi:hpi cyclonedx:makeAggregateBom
+      - uses: actions/upload-artifact@v4
+        with:
+          name: stackrox-container-image-scanner.hpi
+          path: stackrox-container-image-scanner/target/stackrox-container-image-scanner.hpi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: stackrox-container-image-scanner.jar
+          path: stackrox-container-image-scanner/target/stackrox-container-image-scanner.jar
 
-    - name: Perform CodeQL Analysis
-      if: github.event_name == 'push'
-      uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        if: github.event_name == 'push'
+        uses: github/codeql-action/analyze@v3
 
   e2e:
     if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
-      with:
-        repository: stackrox/stackrox
-        path: stackrox
-    - uses: docker/setup-buildx-action@v3
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '11'
-        cache: 'gradle'
-    - name: Install kubectl
-      run: sudo snap install kubectl --classic
-    - name: Install gcloud
-      run: |
-        sudo snap install google-cloud-cli --classic
-        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-        sudo apt-get update
-        sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
-    - uses: actions/download-artifact@v4
-      with:
-        name: stackrox-container-image-scanner.hpi
-        path: jenkins
-    - uses: actions/download-artifact@v4
-      with:
-        name: stackrox-container-image-scanner.hpi
-        path: stackrox-container-image-scanner/target/
-    - name: Build jenkins image
-      uses: docker/build-push-action@v5
-      with:
-        tags: jenkins-test
-        context: jenkins
-        push: false
-        load: true
-    - name: Run jenkins in background
-      run: docker run -d --add-host host.docker.internal:host-gateway -p 8080:8080 jenkins-test
-    - name: Create GKE cluster
-      id: create-cluster
-      env:
-        GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
-      run: |
-        cd stackrox
-        source "scripts/ci/gke.sh"
-        provision_gke_cluster "jenkins-plugin-e2e"
-        echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
-        wait_for_cluster
-    - name: Deploy Stackrox
-      id: deploy
-      env:
-        MAIN_IMAGE_TAG: latest
-        MONITORING_SUPPORT: false
-      run: |
-        cd stackrox
-        ./deploy/k8s/central.sh
-        pass=$(cat deploy/k8s/central-deploy/password)
-        echo "ROX_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> $GITHUB_OUTPUT
-    - name: Wait for API
-      run: |
-        cd stackrox
-        source "tests/e2e/lib.sh"
-        export USE_MIDSTREAM_IMAGES=false
-        wait_for_api
-    - name: Run tests
-      env:
-        ROX_PASSWORD: ${{ steps.deploy.outputs.ROX_PASSWORD }}
-        ROX_ENDPOINT: https://localhost:8000
-        JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
-      run: make -C functionaltest-jenkins-plugin test
-    - name: Teardown GKE cluster
-      if: always() && steps.create-cluster.outputs.CLUSTER_NAME != ''
-      env:
-        CLUSTER_NAME: ${{ steps.create-cluster.outputs.CLUSTER_NAME }}
-      run: |
-        source "stackrox/scripts/ci/gke.sh"
-        teardown_gke_cluster
+      - uses: actions/checkout@v4
+      - name: Setup infractl
+        uses: stackrox/actions/infra/install-infractl@main
+      - uses: actions/checkout@v4
+        with:
+          repository: stackrox/stackrox
+          path: stackrox
+      - uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: stackrox-container-image-scanner.hpi
+          path: jenkins
+      - uses: actions/download-artifact@v4
+        with:
+          name: stackrox-container-image-scanner.hpi
+          path: stackrox-container-image-scanner/target/
+      - name: Build jenkins image
+        uses: docker/build-push-action@v5
+        with:
+          tags: jenkins-test
+          context: jenkins
+          push: false
+          load: true
+      - name: Run jenkins in background
+        run: docker run -d --add-host host.docker.internal:host-gateway -p 8080:8080 jenkins-test
+
+      - name: Create GKE infra cluster
+        uses: stackrox/actions/infra/create-cluster@v1.0.14
+        with:
+          token: ${{ secrets.INFRA_TOKEN }}
+          flavor: qa-demo
+          name: jenkins-plugin-${{ github.run_id }}
+          lifespan: 1h
+          args: main-image=quay.io/stackrox-io/main:latest
+          wait: "true"
+          no-slack: "true"
+      - name: Setup environment from cluster artifacts
+        env:
+          CLUSTER_NAME: jenkins-plugin-${{ github.run_id }}
+          INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
+          ARTIFACTS_DIR: ${{ runner.temp }}/gke-artifacts
+        run: |
+          # Fetch the artifacts for the GKE cluster.
+          infractl artifacts --download-dir=${ARTIFACTS_DIR} ${CLUSTER_NAME} >/dev/null
+          # Set both URL and admin password.
+          ROX_PASSWORD=$(cat ${ARTIFACTS_DIR}/admin-password)
+          ROX_ENDPOINT=https://$(cat ${ARTIFACTS_DIR}/url)
+          echo "::add-mask::$ROX_PASSWORD"
+          echo "::add-mask::$ROX_ENDPOINT"
+          echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
+          echo "ROX_ENDPOINT=$ROX_ENDPOINT" >> $GITHUB_ENV   
+
+      - name: Run tests
+        env:
+          JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
+        run: make -C functionaltest-jenkins-plugin test
+
+      - name: Teardown cluster
+        if: always()
+        env:
+          INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
+        run: |
+          infractl delete jenkins-plugin-${{ github.run_id }} || echo "Failed to remove the infra cluster"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,7 +111,7 @@ jobs:
           infractl artifacts --download-dir=${ARTIFACTS_DIR} ${CLUSTER_NAME} >/dev/null
           # Set both URL and admin password.
           ROX_PASSWORD=$(cat ${ARTIFACTS_DIR}/admin-password)
-          ROX_ENDPOINT=https://$(cat ${ARTIFACTS_DIR}/url)
+          ROX_ENDPOINT=$(cat ${ARTIFACTS_DIR}/url)
           echo "::add-mask::$ROX_PASSWORD"
           echo "::add-mask::$ROX_ENDPOINT"
           echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
@@ -119,6 +119,7 @@ jobs:
 
       - name: Run tests
         env:
+          ROX_ENDPOINT: https://${{ env.ROX_ENDPOINT }}
           JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
         run: make -C functionaltest-jenkins-plugin test
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,7 +113,7 @@ jobs:
           ROX_PASSWORD=$(cat ${ARTIFACTS_DIR}/admin-password)
           ROX_ENDPOINT=$(cat ${ARTIFACTS_DIR}/url)
           echo "::add-mask::$ROX_PASSWORD"
-          echo "::add-mask::$ROX_ENDPOINT"
+          #echo "::add-mask::$ROX_ENDPOINT"
           echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
           echo "ROX_ENDPOINT=$ROX_ENDPOINT" >> $GITHUB_ENV   
 
@@ -121,7 +121,9 @@ jobs:
         env:
           ROX_ENDPOINT: https://${{ env.ROX_ENDPOINT }}
           JENKINS_ROX_ENDPOINT: https://host.docker.internal:8000
-        run: make -C functionaltest-jenkins-plugin test
+        run: |
+          echo $ROX_ENDPOINT
+          make -C functionaltest-jenkins-plugin test
 
       - name: Teardown cluster
         if: always()

--- a/functionaltest-jenkins-plugin/src/main/groovy/util/Config.groovy
+++ b/functionaltest-jenkins-plugin/src/main/groovy/util/Config.groovy
@@ -4,10 +4,6 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class Config {
-    static String getCentralUri() {
-        return getEnv("JENKINS_ROX_ENDPOINT")
-    }
-
     static String getRoxEndpoint() {
         return getEnv("ROX_ENDPOINT")
     }

--- a/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
+++ b/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
@@ -19,7 +19,7 @@ import spock.lang.Unroll
 
 class ImageScanningTest extends BaseSpecification {
 
-    protected static final String CENTRAL_URI = Config.centralUri
+    protected static final String CENTRAL_URI = Config.roxEndpoint
     protected static final String QUAY_REPO = "quay.io/openshifttest/"
 
     @Unroll


### PR DESCRIPTION
# Description

Refactor the E2E tests to make use of the infractl clusters, removing the dependency on the stackrox repository.

This does create an overhead on the creation time of the cluster (it will now take 20-25 minutes to create the cluster) but that is acceptable for the lowered maintenance effort.
