### PR TITLE
fix: set user agent

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
@@ -165,28 +165,27 @@ public class ApiClientFactory {
     }
 
     public static class UserAgentInterceptor implements Interceptor {
-        public static final String STACKROX_CONTAINER_IMAGE_SCANNER = "stackrox-container-image-scanner";
+        private static final String STACKROX_CONTAINER_IMAGE_SCANNER = "stackrox-container-image-scanner";
+        private static final String VALUE = String.format("%s%s (%s; %s) %s",
+                STACKROX_CONTAINER_IMAGE_SCANNER,
+                getVersion(),
+                System.getProperty("os.name"),
+                System.getProperty("os.arch"),
+                "CI"
+        );
 
         @NotNull
         @Override
         public Response intercept(@NotNull Chain chain) throws IOException {
-            String value = String.format("%s/%s (%s; %s) %s",
-                    STACKROX_CONTAINER_IMAGE_SCANNER,
-                    getVersion(),
-                    System.getProperty("os.name"),
-                    System.getProperty("os.arch"),
-                    "CI"
-            );
-
             return chain.proceed(
                     chain.request()
                             .newBuilder()
-                            .header("User-Agent", value)
+                            .header("User-Agent", VALUE)
                             .build()
             );
         }
 
-        String getVersion() {
+        static String getVersion() {
             Jenkins jenkins = Jenkins.getInstanceOrNull();
             if (jenkins == null) {
                 return "";
@@ -196,7 +195,7 @@ public class ApiClientFactory {
             if (plugin == null) {
                 return "";
             }
-            return String.format("%s:%s", plugin.getVersion(), Jenkins.getVersion()).replaceAll("\\s+", "_");
+            return String.format("/%s:%s", plugin.getVersion(), Jenkins.getVersion()).replaceAll("\\s+", "_");
         }
     }
 }

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
@@ -196,7 +196,7 @@ public class ApiClientFactory {
             if (plugin == null) {
                 return "";
             }
-            return String.format("%s:%s", plugin.getVersion(), Jenkins.getVersion());
+            return String.format("%s:%s", plugin.getVersion(), Jenkins.getVersion()).replaceAll("\\s+", "_");
         }
     }
 }

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
@@ -37,7 +37,7 @@ class ApiClientFactoryTest {
 
     @BeforeAll
     static void beforeAll() {
-        SERVER.stubFor(get(anyUrl()).withHeader("User-Agent", matching("stackrox-container-image-scanner/.* CI")).willReturn(ok().withBody("{}")));
+        SERVER.stubFor(get(anyUrl()).withHeader("User-Agent", matching("stackrox-container-image-scanner .* CI")).willReturn(ok().withBody("{}")));
         SERVER.start();
     }
 

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
@@ -2,6 +2,7 @@ package com.stackrox.jenkins.plugins.services;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.stackrox.jenkins.plugins.services.ApiClientFactory.StackRoxTlsValidationMode.VALIDATE;
@@ -36,12 +37,13 @@ class ApiClientFactoryTest {
 
     @BeforeAll
     static void beforeAll() {
-        SERVER.stubFor(get(anyUrl()).willReturn(ok().withBody("{}")));
+        SERVER.stubFor(get(anyUrl()).withHeader("User-Agent", matching("stackrox-container-image-scanner/.* CI")).willReturn(ok().withBody("{}")));
         SERVER.start();
     }
 
     @AfterAll
     static void cleanup() {
+
         SERVER.stop();
     }
 


### PR DESCRIPTION
# Description

This PR adds a  custom UserAgent for request made by plugin. The format is 
```xml
<plugin-name>/<plugin-version>:<jenkins-version> (<os>; <arch>) CI
```
Example:
```python
stackrox-container-image-scanner/1.4.1-SNAPSHOT_(private-a8df60e6-janisz):2.164.1 (Linux; amd64) CI
```

Refs:
https://github.com/stackrox/stackrox/blob/ff73e395a8b08bedd64ecf42d4cc0ccaa2de2673/pkg/clientconn/useragent.go#L28-L38