### PR TITLE
fix: missing jquery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     open-pull-requests-limit: 1
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "org.webjars.*"
 
   - package-ecosystem: 'gradle'
     directory: 'functionaltest-jenkins-plugin/'

--- a/stackrox-container-image-scanner/pom.xml
+++ b/stackrox-container-image-scanner/pom.xml
@@ -14,6 +14,9 @@
     <properties>
         <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
+        <jquery.version>3.4.1</jquery.version>
+        <datatables.version>1.10.20</datatables.version>
+        <bootstrap.version>4.4.1</bootstrap.version>
     </properties>
     <name>StackRox Container Image Scanner</name>
     <description>This plugin provides vulnerability scanning of container images for OS packages and language
@@ -254,13 +257,13 @@
                                 <artifactItem>
                                     <groupId>org.webjars</groupId>
                                     <artifactId>jquery</artifactId>
-                                    <version>3.7.1</version>
+                                    <version>${jquery.version}</version>
                                     <includes>**/jquery*.min.js</includes>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.webjars</groupId>
                                     <artifactId>datatables</artifactId>
-                                    <version>2.1.0</version>
+                                    <version>${datatables.version}</version>
                                     <includes>
                                         **/jquery.dataTables.min.js,**/dataTables.bootstrap.min.js,**/dataTables.bootstrap.min.css,**/fonts/*
                                     </includes>
@@ -268,7 +271,7 @@
                                 <artifactItem>
                                     <groupId>org.webjars</groupId>
                                     <artifactId>bootstrap</artifactId>
-                                    <version>5.3.3</version>
+                                    <version>${bootstrap.version}</version>
                                     <includes>**/bootstrap.min.css,**/bootstrap.min.js,**/fonts/*</includes>
                                 </artifactItem>
                             </artifactItems>
@@ -294,17 +297,17 @@
                             <resources>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/webjars/META-INF/resources/webjars/jquery/3.4.1
+                                        ${project.build.directory}/webjars/META-INF/resources/webjars/jquery/${jquery.version}
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/webjars/META-INF/resources/webjars/datatables/1.10.20
+                                        ${project.build.directory}/webjars/META-INF/resources/webjars/datatables/${datatables.version}
                                     </directory>
                                 </resource>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/webjars/META-INF/resources/webjars/bootstrap/4.4.1
+                                        ${project.build.directory}/webjars/META-INF/resources/webjars/bootstrap/${bootstrap.version}
                                     </directory>
                                 </resource>
                                 <!-- also copy existing resources to use them in the HPL for testing -->


### PR DESCRIPTION
# Description

We previously hardcoded the paths to webjars, including their versions. When Dependabot updated dependencies, these hardcoded paths were not updated, leading to missing JS and CSS files.

To prevent this issue, this PR moves the versioning to a property, ensuring paths are dynamically updated. Since webjar changes affect the UI and we do not have visual regression tests in place, this PR also excludes webjars from Dependabot updates. Additionally, as there might be breaking changes in JS/CSS, this PR reverts the recent webjar upgrades.

### This PR reverts changes from:

- #338
- #340
- #369

### Fixes: 
- #416
