### PR TITLE
fix release draft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # Write permission is required to create a github release
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Current builds fails with `Error: Resource not accessible by integration` this should fix the problem by granting permissions

