### PR TITLE
increase read timeout for HTTP

### DIFF
--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
@@ -43,6 +43,7 @@ public class ApiClientFactory {
     }
 
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration READ_TIMEOUT = Duration.ofMinutes(10);
     private static final int MAXIMUM_CACHE_SIZE = 5; // arbitrary chosen as there are no data to support this decision
 
     @Data
@@ -100,7 +101,7 @@ public class ApiClientFactory {
         }
         builder.retryOnConnectionFailure(true);
         builder.connectTimeout(TIMEOUT);
-        builder.readTimeout(TIMEOUT);
+        builder.readTimeout(READ_TIMEOUT);
         builder.writeTimeout(TIMEOUT);
         builder.addNetworkInterceptor(new UserAgentInterceptor());
         return builder.build();


### PR DESCRIPTION
This PR increases HTTP timeout to 10 minutes to match roxctl defaults. In following PR we will make it configurable or add polling if api supports this feature.

- https://github.com/stackrox/stackrox/blame/4.8.1/roxctl/image/image.go#L24-L29
- https://github.com/stackrox/jenkins-plugin/issues/414