### PR TITLE
configurable read timeout for image scanning

### DIFF
--- a/functionaltest-jenkins-plugin/resources/template.xml
+++ b/functionaltest-jenkins-plugin/resources/template.xml
@@ -21,6 +21,7 @@
             <failOnPolicyEvalFailure></failOnPolicyEvalFailure>
             <failOnCriticalPluginError></failOnCriticalPluginError>
             <enableTLSVerification></enableTLSVerification>
+            <readTimeoutSeconds></readTimeoutSeconds>
         </com.stackrox.jenkins.plugins.StackroxBuilder>
     </builders>
     <publishers/>

--- a/functionaltest-jenkins-plugin/resources/templateNoFile.xml
+++ b/functionaltest-jenkins-plugin/resources/templateNoFile.xml
@@ -18,6 +18,7 @@
             <failOnPolicyEvalFailure></failOnPolicyEvalFailure>
             <failOnCriticalPluginError></failOnCriticalPluginError>
             <enableTLSVerification></enableTLSVerification>
+            <readTimeoutSeconds></readTimeoutSeconds>
             <imageNames></imageNames>
         </com.stackrox.jenkins.plugins.StackroxBuilder>
     </builders>

--- a/functionaltest-jenkins-plugin/src/main/groovy/JenkinsClient.groovy
+++ b/functionaltest-jenkins-plugin/src/main/groovy/JenkinsClient.groovy
@@ -49,7 +49,16 @@ class JenkinsClient {
     static String createJobConfig(String imageName, String portalAddress, String token, Boolean policyEvalCheck,
                                   Boolean failOnCriticalPluginError) {
         Map<String, Serializable> param = createConfigMap(
-                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError)
+                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError, null)
+        // parse the xml
+        String path = TEMPLATE_WITHOUT_IMAGE_NAMES
+        return createJobConfigFromPath(path, param)
+    }
+
+    static String createJobConfig(String imageName, String portalAddress, String token, Boolean policyEvalCheck,
+                                  Boolean failOnCriticalPluginError, Integer readTimeoutSeconds) {
+        Map<String, Serializable> param = createConfigMap(
+                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError, readTimeoutSeconds)
         // parse the xml
         String path = TEMPLATE_WITHOUT_IMAGE_NAMES
         return createJobConfigFromPath(path, param)
@@ -58,7 +67,16 @@ class JenkinsClient {
     static String createJobConfigNoFile(String imageName, String portalAddress, String token, Boolean policyEvalCheck,
                                         Boolean failOnCriticalPluginError) {
         Map<String, Serializable> param = createConfigMap(
-                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError)
+                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError, null)
+        // parse the xml
+        String path = JOB_TEMPLATE_WITH_IMAGE_NAMES
+        return createJobConfigFromPath(path, param)
+    }
+
+    static String createJobConfigNoFile(String imageName, String portalAddress, String token, Boolean policyEvalCheck,
+                                        Boolean failOnCriticalPluginError, Integer readTimeoutSeconds) {
+        Map<String, Serializable> param = createConfigMap(
+                imageName, portalAddress, token, policyEvalCheck, failOnCriticalPluginError, readTimeoutSeconds)
         // parse the xml
         String path = JOB_TEMPLATE_WITH_IMAGE_NAMES
         return createJobConfigFromPath(path, param)
@@ -67,8 +85,9 @@ class JenkinsClient {
     //TODO(ROX-8458): add tests for pipeline
     private static Map<String, Serializable> createConfigMap(String imageName, String portalAddress, String token,
                                                              boolean policyEvalCheck,
-                                                             boolean failOnCriticalPluginError) {
-        return [  // codenarc-disable UnnecessaryCast
+                                                             boolean failOnCriticalPluginError,
+                                                             Integer readTimeoutSeconds) {
+        Map<String, Serializable> configMap = [  // codenarc-disable UnnecessaryCast
                 command                  : """mkdir \$BUILD_TAG
                                cd \$BUILD_TAG
                                echo '${imageName}' >> rox_images_to_scan""",
@@ -79,6 +98,12 @@ class JenkinsClient {
                 enableTLSVerification    : false,
                 imageNames               : imageName,
         ] as Map<String, Serializable>
+
+        if (readTimeoutSeconds != null) {
+            configMap.readTimeoutSeconds = readTimeoutSeconds
+        }
+
+        return configMap
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)

--- a/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
+++ b/functionaltest-jenkins-plugin/src/test/groovy/ImageScanningTest.groovy
@@ -22,6 +22,15 @@ class ImageScanningTest extends BaseSpecification {
     protected static final String CENTRAL_URI = Config.roxEndpoint
     protected static final String QUAY_REPO = "quay.io/openshifttest/"
 
+    def "Test read timeout with minimal timeout should fail"() {
+        when:
+        BuildResult status = jenkins.createAndRunJob(
+                getJobConfigWithTimeout("nginx-alpine:latest", false, true, 1))
+
+        then:
+        assert status == FAILURE
+    }
+
     @Unroll
     def "image scanning test with toggle enforcement(#imageName, #policyName,  #enforcements, #endStatus)"() {
         given:
@@ -92,6 +101,10 @@ class ImageScanningTest extends BaseSpecification {
 
     String getJobConfig(String imageName, Boolean policyEvalCheck, Boolean failOnCriticalPluginError) {
         return createJobConfig(QUAY_REPO + imageName, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError)
+    }
+
+    String getJobConfigWithTimeout(String imageName, Boolean policyEvalCheck, Boolean failOnCriticalPluginError, Integer readTimeoutSeconds) {
+        return createJobConfig(QUAY_REPO + imageName, CENTRAL_URI, token, policyEvalCheck, failOnCriticalPluginError, readTimeoutSeconds)
     }
 
     StoragePolicy updatePolicy(String policyName, String tag, List<StorageEnforcementAction> enforcements) {

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/StackroxBuilder.java
@@ -75,6 +75,8 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
     private String caCertPEM;
     @DataBoundSetter
     private String cluster;
+    @DataBoundSetter
+    private int readTimeoutSeconds = 600;
 
     private RunConfig runConfig;
 
@@ -150,7 +152,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
         List<ImageCheckResults> results = Lists.newArrayList();
 
         ApiClient apiClient = ApiClientFactory.newApiClient(
-                getPortalAddress(), getApiToken().getPlainText(), getCaCertPEM(), getTLSValidationMode());
+                getPortalAddress(), getApiToken().getPlainText(), getCaCertPEM(), getTLSValidationMode(), getReadTimeoutSeconds());
         ImageService imageService = new ImageService(apiClient);
         DetectionService detectionService = new DetectionService(apiClient);
 
@@ -250,6 +252,16 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
         }
 
         @SuppressWarnings("unused")
+        public FormValidation doCheckReadTimeoutSeconds(@QueryParameter final int readTimeoutSeconds) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            if (readTimeoutSeconds > 0 && readTimeoutSeconds <= 3600) {
+                return FormValidation.ok();
+            } else {
+                return FormValidation.error("Read timeout must be between 1 and 3600 seconds.");
+            }
+        }
+
+        @SuppressWarnings("unused")
         @POST
         public FormValidation doTestConnection(@QueryParameter("portalAddress") final String portalAddress, @QueryParameter("apiToken") final String apiToken,
                                                @QueryParameter("enableTLSVerification") final boolean tlsVerify, @QueryParameter("caCertPEM") final String caCertPEM) {
@@ -275,7 +287,7 @@ public class StackroxBuilder extends Builder implements SimpleBuildStep {
         }
 
         private boolean checkRoxAuthStatus(final String portalAddress, final String apiToken, final boolean tlsVerify, final String caCertPEM) throws IOException {
-            ApiClient apiClient = ApiClientFactory.newApiClient(portalAddress, apiToken, caCertPEM, validationMode(tlsVerify));
+            ApiClient apiClient = ApiClientFactory.newApiClient(portalAddress, apiToken, caCertPEM, validationMode(tlsVerify), 10);
             try {
                 V1AuthStatus status = new AuthServiceApi(apiClient).authServiceGetAuthStatus();
                 return !Strings.isNullOrEmpty(status.getUserId());

--- a/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
+++ b/stackrox-container-image-scanner/src/main/java/com/stackrox/jenkins/plugins/services/ApiClientFactory.java
@@ -43,13 +43,13 @@ public class ApiClientFactory {
     }
 
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
-    private static final Duration READ_TIMEOUT = Duration.ofMinutes(10);
     private static final int MAXIMUM_CACHE_SIZE = 5; // arbitrary chosen as there are no data to support this decision
 
     @Data
     private static class CacheKey {
         private final String caCert;
         private final StackRoxTlsValidationMode tlsValidationMode;
+        private final int readTimeoutSeconds;
     }
 
     // It is good practice to avoid creating OkHttpClient on each request.
@@ -61,13 +61,13 @@ public class ApiClientFactory {
                     new CacheLoader<CacheKey, OkHttpClient>() {
                         @Override
                         public OkHttpClient load(@Nonnull CacheKey key) throws IOException {
-                            return newHttpClient(key.caCert, key.tlsValidationMode);
+                            return newHttpClient(key.caCert, key.tlsValidationMode, key.readTimeoutSeconds);
                         }
                     });
 
 
-    public static ApiClient newApiClient(String basePath, String apiKey, @Nullable String caCert, StackRoxTlsValidationMode tlsValidationMode) throws IOException {
-        OkHttpClient client = getClient(tlsValidationMode, caCert);
+    public static ApiClient newApiClient(String basePath, String apiKey, @Nullable String caCert, StackRoxTlsValidationMode tlsValidationMode, int readTimeoutSeconds) throws IOException {
+        OkHttpClient client = getClient(tlsValidationMode, caCert, readTimeoutSeconds);
         ApiClient apiClient = new ApiClient(client);
         apiClient.setBearerToken(apiKey);
         apiClient.setBasePath(basePath);
@@ -75,16 +75,19 @@ public class ApiClientFactory {
     }
 
     @Nonnull
-    static OkHttpClient getClient(StackRoxTlsValidationMode tlsValidationMode, @Nullable String caCert) throws IOException {
+    static OkHttpClient getClient(StackRoxTlsValidationMode tlsValidationMode, @Nullable String caCert, int readTimeoutSeconds) throws IOException {
         try {
-            return CLIENT_CACHE.get(new CacheKey(caCert, tlsValidationMode));
+            return CLIENT_CACHE.get(new CacheKey(caCert, tlsValidationMode, readTimeoutSeconds));
         } catch (ExecutionException e) {
             throw new IOException("Could not get HTTP client from cache", e);
         }
     }
 
     @Nonnull
-    private static OkHttpClient newHttpClient(@Nullable String caCert, StackRoxTlsValidationMode tlsValidationMode) throws IOException {
+    private static OkHttpClient newHttpClient(@Nullable String caCert, StackRoxTlsValidationMode tlsValidationMode, int readTimeoutSeconds) throws IOException {
+        if (readTimeoutSeconds < 1) {
+            readTimeoutSeconds = 600;
+        }
         OkHttpClient.Builder builder;
         try {
             if (tlsValidationMode == INSECURE_ACCEPT_ANY) {
@@ -101,7 +104,7 @@ public class ApiClientFactory {
         }
         builder.retryOnConnectionFailure(true);
         builder.connectTimeout(TIMEOUT);
-        builder.readTimeout(READ_TIMEOUT);
+        builder.readTimeout(Duration.ofSeconds(readTimeoutSeconds));
         builder.writeTimeout(TIMEOUT);
         builder.addNetworkInterceptor(new UserAgentInterceptor());
         return builder.build();

--- a/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/StackroxBuilder/config.jelly
+++ b/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/StackroxBuilder/config.jelly
@@ -16,6 +16,10 @@
              help="/plugin/stackrox-container-image-scanner/help/help-cluster.html">
         <f:textbox field="cluster"/>
     </f:entry>
+    <f:entry title="${%ReadTimeoutTitle}"
+             help="/plugin/stackrox-container-image-scanner/help/help-readTimeoutSeconds.html">
+        <f:number field="readTimeoutSeconds" min="1" max="3600" step="1" default="600"/>
+    </f:entry>
     <f:entry>
         <j:if test="${instance != null}">
             <f:optionalBlock title="${%EnableTLSVerification}" name="enableTLSVerification"

--- a/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/StackroxBuilder/config.properties
+++ b/stackrox-container-image-scanner/src/main/resources/com/stackrox/jenkins/plugins/StackroxBuilder/config.properties
@@ -7,3 +7,4 @@ EnableTLSVerification=Enable TLS verification
 CACertificate=CA Certificate
 ImageNames=Image Names
 ClusterTitle=Cluster
+ReadTimeoutTitle=Read Timeout (seconds)

--- a/stackrox-container-image-scanner/src/main/webapp/help/help-readTimeoutSeconds.html
+++ b/stackrox-container-image-scanner/src/main/webapp/help/help-readTimeoutSeconds.html
@@ -1,0 +1,4 @@
+<div>
+    HTTP read timeout in seconds for API requests to StackRox portal.
+    Increase this value if you experience timeout errors during image scans.
+</div>

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/AbstractServiceTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/AbstractServiceTest.java
@@ -24,7 +24,7 @@ public abstract class AbstractServiceTest {
     @BeforeAll
     static void setup() throws IOException {
         MOCK_SERVER.start();
-        client = ApiClientFactory.newApiClient(MOCK_SERVER.baseUrl(), MOCK_TOKEN.getPlainText(), "", INSECURE_ACCEPT_ANY);
+        client = ApiClientFactory.newApiClient(MOCK_SERVER.baseUrl(), MOCK_TOKEN.getPlainText(), "", INSECURE_ACCEPT_ANY, 1);
     }
 
     @AfterAll

--- a/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
+++ b/stackrox-container-image-scanner/src/test/java/com/stackrox/jenkins/plugins/services/ApiClientFactoryTest.java
@@ -54,7 +54,7 @@ class ApiClientFactoryTest {
         File caPemFile = Paths.get("src", "test", "resources", "cert", "localhost.pem").toFile();
         String pem = useCaCert ? FileUtils.readFileToString(caPemFile, StandardCharsets.UTF_8) : null;
 
-        OkHttpClient client = ApiClientFactory.getClient(tlsVerify, pem);
+        OkHttpClient client = ApiClientFactory.getClient(tlsVerify, pem, 1);
 
         Request request = new Request.Builder().url(SERVER.baseUrl()).build();
         Response response = client.newCall(request).execute();
@@ -65,7 +65,7 @@ class ApiClientFactoryTest {
     @Test
     @DisplayName("TLS should FAIL when tlsVerify: true and custom PEM: false")
     void shouldThrowWhenTLSCouldNotBeVerified() throws IOException {
-        OkHttpClient client = ApiClientFactory.getClient(VALIDATE, "");
+        OkHttpClient client = ApiClientFactory.getClient(VALIDATE, "", 1);
 
         Request request = new Request.Builder().url(SERVER.baseUrl()).build();
         Exception exception = assertThrows(IOException.class, () -> client.newCall(request).execute());
@@ -81,7 +81,7 @@ class ApiClientFactoryTest {
         File clientPem = Paths.get("src", "test", "resources", "cert", "client.pem").toFile();
         String pem = FileUtils.readFileToString(clientPem, StandardCharsets.UTF_8);
 
-        OkHttpClient client = ApiClientFactory.getClient(VALIDATE, pem);
+        OkHttpClient client = ApiClientFactory.getClient(VALIDATE, pem, 1);
 
         WireMockServer server = new WireMockServer(wireMockConfig().httpDisabled(true)
                 .dynamicHttpsPort().keystorePath(keyStorePath).keystorePassword(KEY_STORE_PASSWORD));


### PR DESCRIPTION
  Fixes #414

  Summary

  - Added configurable read timeout option to prevent timeouts during large image scans
  - Replaced hardcoded 10-minute read timeout with user-configurable value (1-3600 seconds, default 600)
  - Added new readTimeoutSeconds field to the Jenkins plugin configuration UI

  Changes

  - ApiClientFactory: Modified to accept configurable read timeout parameter instead of hardcoded 10-minute timeout
  - StackroxBuilder: Added new readTimeoutSeconds field with validation (1-3600 seconds)
  - Configuration UI: Added new timeout input field with help text in Jenkins configuration
  - Templates: Updated XML templates to include the new timeout parameter
  - Tests: Added test coverage for timeout functionality and updated existing tests

  Test Plan

  - Added functional test that verifies minimal timeout configuration fails as expected
  - Updated existing tests to use the new timeout parameter
  - Verified UI validation prevents invalid timeout values (must be 1-3600 seconds)

  This change allows users to configure appropriate timeout values for their environment, especially when scanning large Docker images
  that may take longer than the previous 10-minute hardcoded limit.

  🤖 Generated with https://claude.ai/code
  Co-Authored-By: Claude noreply@anthropic.com

