### PR TITLE
fix: wait for scanner

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,8 @@ jobs:
           ROX_PASSWORD=$(cat stackrox/deploy/k8s/central-deploy/password)
           echo "::add-mask::$ROX_PASSWORD"
           echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
+      - name: Wait for scanner to start
+        run: sleep 60
       - name: Add stackrox certificate
         run: scripts/set-certificates.sh
       - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "::add-mask::$ROX_PASSWORD"
           echo "ROX_PASSWORD=$ROX_PASSWORD" >> $GITHUB_ENV
       - name: Wait for scanner to start
-        run: sleep 60
+        run: sleep 120
       - name: Add stackrox certificate
         run: scripts/set-certificates.sh
       - name: Run tests


### PR DESCRIPTION
This in recent PR to speedup stackrox deployment I removed 2 minutes wait. The comment claims it's just for GKE but it looks like it's required to allow scanner setup. This PR adds 1 minute sleep. In the future after we update api.yml we can use scanner status health to detect when scanner is ready.

- https://github.com/stackrox/stackrox/pull/16314